### PR TITLE
 Change size parameters to kilobytes, not bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,22 +75,23 @@ provides access to the shared memory. Throws an exception on error.
 __Arguments__
 
 * `path` - The path of the file to create
-* `file_size` - *Optional* The initial size of the file in bytes. If
-  more space is needed, the file will automatically be grown to a
-  larger size. Minimum is 500 bytes. Defaults to 5 megabytes.
+* `file_size` - *Optional* The initial size of the file in
+  kilobytes. If more space is needed, the file will automatically be
+  grown to a larger size. Minimum is 500 bytes. Defaults to 5
+  megabytes.
 * `initial_bucket_count` - *Optional* The number of buckets to
   allocate initially. This is passed to the underlying
   [Boost unordered_map](http://www.boost.org/doc/libs/1_38_0/doc/html/boost/unordered_map.html).
   Defaults to 1024. Set this to the number of keys you expect to write.
-* `max_file_size` - *Optional* The largest the file is allowed to
-  grow. If data is added beyond this limit, an exception is thrown.
-  Defaults to 5 gigabytes.
+* `max_file_size` - *Optional* The largest the file is allowed to grow
+  in kilobites. If data is added beyond this limit, an exception is
+  thrown.  Defaults to 5 gigabytes.
 
 __Example__
 
 ```js
 // Create a 500K map for 300 objects.
-const obj = new Shared.Create("/tmp/sharedmem", 500000, 300)
+const obj = new Shared.Create("/tmp/sharedmem", 500, 300)
 ```
 
 ### new Open(path)

--- a/mmap-object.cc
+++ b/mmap-object.cc
@@ -358,8 +358,10 @@ NAN_METHOD(SharedMap::Create) {
 
   Nan::Utf8String filename(info[0]->ToString());
   size_t file_size = (int)info[1]->Int32Value();
+  file_size *= 1024;
   size_t initial_bucket_count = (int)info[2]->Int32Value();
   size_t max_file_size = (int)info[3]->Int32Value();
+  max_file_size *= 1024;
   SharedMap *d = new SharedMap();
 
   if (file_size == 0) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "module_path": "./lib",
     "host": "https://github.com/allenluce/mmap-object/releases/download/{version}"
   },
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "Allen Luce",
   "repository": {
     "type": "git",

--- a/test/test-mmap-object.js
+++ b/test/test-mmap-object.js
@@ -130,14 +130,14 @@ describe('mmap-object', function () {
     it('grows small files', function () {
       const filename = path.join(this.dir, 'grow_me')
       const smallobj = new MmapObject.Create(filename, 500)
-      expect(fs.statSync(filename)['size']).to.equal(500)
+      expect(fs.statSync(filename)['size']).to.equal(512000)
       smallobj['key'] = new Array(BigKeySize).join('big')
       expect(fs.statSync(filename)['size']).to.above(500)
     })
 
     it('bombs when file gets too big', function () {
       const filename = path.join(this.dir, 'bomb_me')
-      const smallobj = new MmapObject.Create(filename, 500, 4, 20000)
+      const smallobj = new MmapObject.Create(filename, 1, 4, 20)
       smallobj['key'] = new Array(BigKeySize).join('big')
       expect(function () {
         smallobj['otherkey'] = new Array(BigKeySize).join('big')
@@ -168,7 +168,7 @@ describe('mmap-object', function () {
     })
 
     it('bucket_count', function () {
-      this.obj = new MmapObject.Create(path.join(this.dir, 'bucket_counter'), 5000, 4)
+      this.obj = new MmapObject.Create(path.join(this.dir, 'bucket_counter'), 5, 4)
       expect(this.obj.bucket_count()).to.equal(4)
       this.obj.one = 'value'
       this.obj.two = 'value'

--- a/test/test-mmap-object.js
+++ b/test/test-mmap-object.js
@@ -239,7 +239,7 @@ describe('mmap-object', function () {
       expect(function () {
         const obj = new MmapObject.Open('/tmp/no_file_at_all')
         expect(obj).to.not.exist
-      }).to.throw(/.tmp.no_file_at_all does not exist./)
+      }).to.throw(/.tmp.no_file_at_all does not exist.|.tmp.no_file_at_all: No such file or directory/)
     })
 
     it('read after close gives exception', function () {


### PR DESCRIPTION
So that Int32Value can still be used but support more than 2^32 for a file size.

API-affecting change, so increase minor.
